### PR TITLE
Reload security

### DIFF
--- a/EXPERIMENTAL.adoc
+++ b/EXPERIMENTAL.adoc
@@ -19,7 +19,7 @@ The quickest way to build is:
 The `spring-boot-developer-tools` contains auto-configuration for remote debug tunneling.
 See `spring-boot-sample-tunnel` for an example. To enable tunneling you need to add
 a dependency to the `spring-boot-developer-tools` project and set
-`spring.developertools.remote.enabled=true` in your `application.properties` file.
+`spring.developertools.remote.secret=somesecret` in your `application.properties` file.
 
 You also need to start the remote app with the Java flags
 `-Xdebug -Xrunjdwp:server=y,transport=dt_socket,suspend=n`

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/autoconfigure/remote/RemoteDeveloperToolsProperties.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/autoconfigure/remote/RemoteDeveloperToolsProperties.java
@@ -13,32 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.boot.developertools.autoconfigure.remote;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Phillip Webb
+ * @author Rob Winch
+ * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.developertools.remote")
 public class RemoteDeveloperToolsProperties {
 
 	public static final String DEFAULT_CONTEXT_PATH = "/~~~springboot~~~";
 
-	private boolean enabled = false;
+	/**
+	 * The default value for {@link #getSecretHeaderName()}
+	 */
+	public static final String DEFAULT_SECRET_HEADER_NAME = "X-AUTH-TOKEN";
 
 	private Debug debug = new Debug();
 
 	private String contextPath = DEFAULT_CONTEXT_PATH;
 
-	public boolean getEnabled() {
-		return this.enabled;
-	}
+	private String secret;
 
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
+	private String secretHeaderName = DEFAULT_SECRET_HEADER_NAME;
 
 	public String getContextPath() {
 		return this.contextPath;
@@ -54,6 +54,46 @@ public class RemoteDeveloperToolsProperties {
 
 	public void setDebug(Debug debug) {
 		this.debug = debug;
+	}
+
+	/**
+	 * Gets the secret required to be present in the header defined by
+	 * {@link #getSecretHeaderName()}.
+	 *
+	 * @return the secret required to be present in the header defined by
+	 * {@link #getSecretHeaderName()}
+	 */
+	public String getSecret() {
+		return secret;
+	}
+
+	/**
+	 * Sets the secret required to be present in the header defined by
+	 * {@link #getSecretHeaderName()}.
+	 *
+	 * @param secret the secret that will be required.
+	 */
+	public void setSecret(String secret) {
+		this.secret = secret;
+	}
+
+	/**
+	 * Gets the header name that must have {@link #getSecret()}. The default is
+	 * {@link #DEFAULT_SECRET_HEADER_NAME}.
+	 *
+	 * @return the header name that must have {@link #getSecret()}
+	 */
+	public String getSecretHeaderName() {
+		return secretHeaderName;
+	}
+
+	/**
+	 * Sets the header name that must have {@link #getSecret()}
+	 *
+	 * @param secretHeaderName the header name that must have {@link #getSecret()}
+	 */
+	public void setSecretHeaderName(String secretHeaderName) {
+		this.secretHeaderName = secretHeaderName;
 	}
 
 	public static class Debug {

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/client/HeaderClientHttpRequestInterceptor.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/client/HeaderClientHttpRequestInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.tunnel.client;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * Allows populating an arbitrary header with a value. For example, it might be used to provide an X-AUTH-TOKEN and value for security purposes.
+ * </p>
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+public class HeaderClientHttpRequestInterceptor implements
+		ClientHttpRequestInterceptor {
+
+	private final String headerName;
+	private final String headerValue;
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param headerName the header name to populate. Cannot be null or empty.
+	 * @param headerValue the header value to populate. Cannot be null or empty.
+	 */
+	public HeaderClientHttpRequestInterceptor(String headerName, String headerValue) {
+		assertNotNullEmpty(headerName, "headerName");
+		assertNotNullEmpty(headerValue, "headerValue");
+
+		this.headerName = headerName;
+		this.headerValue = headerValue;
+	}
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+			ClientHttpRequestExecution execution) throws IOException {
+
+		request.getHeaders().add(headerName, headerValue);
+		return execution.execute(request, body);
+	}
+
+	private static void assertNotNullEmpty(String value, String name) {
+		Assert.notNull(value, name + " must not be null");
+		Assert.hasLength(value, name + " must not be empty");
+	}
+}

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/server/SecuredServerHttpRequestMatcher.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/server/SecuredServerHttpRequestMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.tunnel.server;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.util.Assert;
+
+/**
+ * Creates a matcher that matches on the requestURI and requires a secret to be present in the header.
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+public class SecuredServerHttpRequestMatcher implements ServerHttpRequestMatcher {
+	private final String requestURI;
+
+	private final String secretHeaderName;
+
+	private final String expectedSecret;
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param requestURI the requestURI to match on.
+	 * @param secretHeaderName the name of the header that must contain the secret.
+	 * @param expectedSecret the expected value of the header (i.e. a password)
+	 */
+	public SecuredServerHttpRequestMatcher(String requestURI, String secretHeaderName, String expectedSecret) {
+		Assert.notNull(requestURI, "requestURI must not be null");
+		Assert.hasLength(requestURI, "requestURI must not be empty");
+		Assert.isTrue(requestURI.startsWith("/"), "requestURI must start with '/'");
+
+		Assert.notNull(secretHeaderName, "secretHeaderName must not be null");
+		Assert.hasLength(secretHeaderName, "secretHeaderName must not be empty");
+
+		Assert.notNull(expectedSecret, "expectedSecret must not be null");
+		Assert.hasLength(expectedSecret, "expectedSecret must not be empty");
+
+		this.requestURI = requestURI;
+		this.secretHeaderName = secretHeaderName;
+		this.expectedSecret = expectedSecret;
+	}
+
+	@Override
+	public boolean matches(ServerHttpRequest request) {
+		if(!requestURI.equals(request.getURI().getPath())) {
+			return false;
+		}
+
+		String providedSecret = request.getHeaders().getFirst(secretHeaderName);
+		if(!expectedSecret.equals(providedSecret)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/server/ServerHttpRequestMatcher.java
+++ b/spring-boot-developer-tools/src/main/java/org/springframework/boot/developertools/tunnel/server/ServerHttpRequestMatcher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.tunnel.server;
+
+import org.springframework.http.server.ServerHttpRequest;
+
+/**
+ * Strategy to determine if a particular ServerHttpRequest matches or not.
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+public interface ServerHttpRequestMatcher {
+
+	/**
+	 * Returns true of the {@link ServerHttpRequest} passed in is considered a match.
+	 *
+	 * @param request the {@link ServerHttpRequest} to evaluate.
+	 * @return true if the {@link ServerHttpRequest} passed in is considered a match, else false
+	 */
+	boolean matches(ServerHttpRequest request);
+}

--- a/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/autoconfigure/remote/RemoteDeveloperToolsAutoConfigurationTests.java
+++ b/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/autoconfigure/remote/RemoteDeveloperToolsAutoConfigurationTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.autoconfigure.remote;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.developertools.tunnel.server.HttpTunnelFilter;
+import org.springframework.boot.developertools.tunnel.server.HttpTunnelServer;
+import org.springframework.boot.developertools.tunnel.server.RemoteDebugPortProvider;
+import org.springframework.boot.developertools.tunnel.server.SocketTargetServerConnection;
+import org.springframework.boot.developertools.tunnel.server.TargetServerConnection;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+/**
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+public class RemoteDeveloperToolsAutoConfigurationTests {
+
+	AnnotationConfigWebApplicationContext context;
+
+	MockHttpServletRequest request;
+	MockHttpServletResponse response;
+	MockFilterChain chain;
+
+	@Before
+	public void setup() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		chain = new MockFilterChain();
+	}
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultSetup() throws Exception {
+		loadContext("spring.developertools.remote.secret:supersecret");
+
+		HttpTunnelFilter filter = this.context.getBean(HttpTunnelFilter.class);
+
+		request.setRequestURI(RemoteDeveloperToolsProperties.DEFAULT_CONTEXT_PATH + "/debug");
+		request.addHeader(RemoteDeveloperToolsProperties.DEFAULT_SECRET_HEADER_NAME, "supersecret");
+
+		filter.doFilter(request, response, chain);
+
+		assertTunnel(true);
+	}
+
+	@Test
+	public void invalidUrlInRequest() throws Exception {
+		loadContext("spring.developertools.remote.secret:supersecret");
+
+		HttpTunnelFilter filter = this.context.getBean(HttpTunnelFilter.class);
+
+		request.setRequestURI("/debug");
+		request.addHeader(RemoteDeveloperToolsProperties.DEFAULT_SECRET_HEADER_NAME, "supersecret");
+
+		filter.doFilter(request, response, chain);
+
+		assertTunnel(false);
+	}
+
+	@Test
+	public void missingSecretInConfigDisables() throws Exception {
+		loadContext("a:b");
+
+		String[] namesForType = this.context.getBeanNamesForType(HttpTunnelFilter.class);
+
+		assertThat(namesForType.length, equalTo(0));
+	}
+
+	@Test
+	public void missingSecretFromRequest() throws Exception {
+		loadContext("spring.developertools.remote.secret:supersecret");
+
+		HttpTunnelFilter filter = this.context.getBean(HttpTunnelFilter.class);
+
+		request.setRequestURI(RemoteDeveloperToolsProperties.DEFAULT_CONTEXT_PATH + "/debug");
+
+		filter.doFilter(request, response, chain);
+
+		assertTunnel(false);
+	}
+
+	@Test
+	public void invalidSecretInRequest() throws Exception {
+		loadContext("spring.developertools.remote.secret:supersecret");
+
+		HttpTunnelFilter filter = this.context.getBean(HttpTunnelFilter.class);
+
+		request.setRequestURI(RemoteDeveloperToolsProperties.DEFAULT_CONTEXT_PATH + "/debug");
+		request.addHeader(RemoteDeveloperToolsProperties.DEFAULT_SECRET_HEADER_NAME, "invalid");
+
+		filter.doFilter(request, response, chain);
+
+		assertTunnel(false);
+	}
+
+	@Test
+	public void customHeaderName() throws Exception {
+		loadContext("spring.developertools.remote.secret:supersecret",
+				"spring.developertools.remote.secretHeaderName:customheader");
+
+		HttpTunnelFilter filter = this.context.getBean(HttpTunnelFilter.class);
+
+		request.setRequestURI(RemoteDeveloperToolsProperties.DEFAULT_CONTEXT_PATH + "/debug");
+		request.addHeader("customheader", "supersecret");
+
+		filter.doFilter(request, response, chain);
+
+		assertTunnel(true);
+	}
+
+	/**
+	 * Asserts that the request tunneled through
+	 *
+	 * @param value
+	 */
+	private void assertTunnel(boolean value) {
+		assertThat(this.context.getBean(MockHttpTunnelServer.class).invoked, equalTo(value));
+	}
+
+	private void loadContext(String...properties) {
+		this.context = new AnnotationConfigWebApplicationContext();
+		this.context.setServletContext(new MockServletContext());
+		this.context.register(Config.class,
+				ServerPropertiesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context, properties);
+		this.context.refresh();
+	}
+
+	@Import(RemoteDeveloperToolsAutoConfiguration.class)
+	@Configuration
+	static class Config {
+
+		@Bean
+		public HttpTunnelServer remoteDebugHttpTunnelServer() {
+			return new MockHttpTunnelServer(new SocketTargetServerConnection(
+					new RemoteDebugPortProvider()));
+		}
+	}
+
+	static class MockHttpTunnelServer extends HttpTunnelServer {
+		private boolean invoked;
+
+		public MockHttpTunnelServer(TargetServerConnection serverConnection) {
+			super(serverConnection);
+		}
+
+		@Override
+		public void handle(ServerHttpRequest request, ServerHttpResponse response)
+				throws IOException {
+			this.invoked = true;
+		}
+	}
+}

--- a/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/remote/RemoteDebugHttpTunnelClientConfigurationTests.java
+++ b/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/remote/RemoteDebugHttpTunnelClientConfigurationTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.remote;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = RemoteDebugHttpTunnelClientConfigurationTests.BootApplication.class)
+@WebIntegrationTest
+public class RemoteDebugHttpTunnelClientConfigurationTests {
+	@Value("${local.server.port}")
+	int port;
+
+	AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void defaultSetup() {
+		context = new AnnotationConfigApplicationContext();
+		this.context.register(Config.class,
+				ServerPropertiesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.developertools.remote.secret:supersecret");
+
+		Map<String, Object> source = Collections.<String,Object>singletonMap("remoteUrl", "http://localhost:"+port);
+		PropertySource<?> propertySource = new MapPropertySource("remoteUrl", source);
+		context.getEnvironment().getPropertySources().addFirst(propertySource);
+		this.context.refresh();
+
+
+		String url = "http://localhost:" + port + "/hello";
+
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(url,
+				String.class);
+
+		assertEquals(HttpStatus.OK, entity.getStatusCode());
+		assertEquals("Hello World", entity.getBody());
+	}
+
+	@Test
+	public void missingSecret() {
+		context = new AnnotationConfigApplicationContext();
+		this.context.register(Config.class,
+				ServerPropertiesAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		EnvironmentTestUtils.addEnvironment(this.context);
+
+		Map<String, Object> source = Collections.<String,Object>singletonMap("remoteUrl", "http://localhost:"+port);
+		PropertySource<?> propertySource = new MapPropertySource("remoteUrl", source);
+		context.getEnvironment().getPropertySources().addFirst(propertySource);
+
+		try {
+			this.context.refresh();
+			fail("Expected Exception");
+		} catch(Exception e) {
+			assertThat(e.getMessage(), containsString("The environment value spring.developertools.remote.secret is required to secure your connection."));
+		}
+
+	}
+
+	@Configuration
+	@Import(RemoteDebugHttpTunnelClientConfiguration.class)
+	static class Config {
+
+	}
+
+	@Configuration
+	@EnableAutoConfiguration(exclude=RemoteDebugHttpTunnelClientConfiguration.class)
+	@RestController
+	static class BootApplication {
+
+		@RequestMapping
+		public String hello() {
+			return "Hello World";
+		}
+	}
+}

--- a/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/client/HeaderClientHttpRequestInterceptorTests.java
+++ b/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/client/HeaderClientHttpRequestInterceptorTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.tunnel.client;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HeaderClientHttpRequestInterceptorTests {
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private String headerName;
+
+	private String headerValue;
+
+	private HeaderClientHttpRequestInterceptor interceptor;
+
+	private HttpRequest request;
+
+	private byte[] body;
+
+	@Mock
+	private ClientHttpRequestExecution execution;
+
+	@Mock
+	private ClientHttpResponse response;
+
+	private MockHttpServletRequest httpRequest;
+
+
+	@Before
+	public void setup() throws IOException {
+		body = new byte[] {};
+		httpRequest = new MockHttpServletRequest();
+		request = new ServletServerHttpRequest(httpRequest);
+		headerName = "X-AUTH-TOKEN";
+		headerValue = "secret";
+
+		when(execution.execute(request, body)).thenReturn(response);
+
+		interceptor = new HeaderClientHttpRequestInterceptor(headerName, headerValue);
+	}
+
+	@Test
+	public void constructorNullHeaderName() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("headerName must not be null");
+
+		new HeaderClientHttpRequestInterceptor(null, headerValue);
+	}
+
+	@Test
+	public void constructorEmptyHeaderName() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("headerName must not be empty");
+
+		new HeaderClientHttpRequestInterceptor("", headerValue);
+	}
+
+	@Test
+	public void constructorNullHeaderValue() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("headerValue must not be null");
+
+		new HeaderClientHttpRequestInterceptor(headerName, null);
+	}
+
+	@Test
+	public void constructorEmptyHeaderValue() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("headerValue must not be empty");
+
+		new HeaderClientHttpRequestInterceptor(headerName, "");
+	}
+
+	@Test
+	public void intercept() throws IOException {
+		ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+		assertThat(request.getHeaders().getFirst(headerName), equalTo(headerValue));
+		assertThat(result, equalTo(response));
+	}
+}

--- a/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/server/SecuredServletServerHttpRequestMatcherTests.java
+++ b/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/server/SecuredServletServerHttpRequestMatcherTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.developertools.tunnel.server;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ *
+ * @author Rob Winch
+ * @since 1.3.0
+ *
+ */
+public class SecuredServletServerHttpRequestMatcherTests {
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private String url;
+
+	private String secretHeaderName;
+
+	private String secret;
+
+	private SecuredServerHttpRequestMatcher matcher;
+
+	private MockHttpServletRequest request;
+
+	@Before
+	public void setup() {
+		this.url = "/tunnel";
+		this.secretHeaderName = "X-AUTH_TOKEN";
+		this.secret = "secret";
+		this.matcher = new SecuredServerHttpRequestMatcher(url, secretHeaderName, secret);
+		this.request = new MockHttpServletRequest("GET", url);
+		this.request.addHeader(secretHeaderName, secret);
+	}
+
+
+	@Test
+	public void constructorUrlMustNotBeEmpty() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("requestURI must not be empty");
+		new SecuredServerHttpRequestMatcher("", secretHeaderName, secret);
+	}
+
+	@Test
+	public void constructorUrlMustStartWithSlash() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("requestURI must start with '/'");
+		new SecuredServerHttpRequestMatcher("tunnel", secretHeaderName, secret);
+	}
+
+	@Test
+	public void constructorSecretHeaderNameMustNotBeNull() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("secretHeaderName must not be null");
+		new SecuredServerHttpRequestMatcher(url, null, secret);
+	}
+
+	@Test
+	public void constructorSecretHeaderNameMustNotBeEmpty() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("secretHeaderName must not be empty");
+		new SecuredServerHttpRequestMatcher(url, "", secret);
+	}
+
+	@Test
+	public void constructorSecretMustNotBeNull() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("expectedSecret must not be null");
+		new SecuredServerHttpRequestMatcher(url, secretHeaderName, null);
+	}
+
+	@Test
+	public void constructorSecretMustNotBeEmpty() throws Exception {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("expectedSecret must not be empty");
+		new SecuredServerHttpRequestMatcher(url, secretHeaderName, "");
+	}
+
+	@Test
+	public void matchesIgnoresDifferentUrl() throws Exception {
+		request.setRequestURI(url + "invalid");
+		assertFalse(this.matcher.matches(new ServletServerHttpRequest(request)));
+	}
+
+	@Test
+	public void matchesIgnoresDifferentSecret() throws Exception {
+		request = new MockHttpServletRequest("GET", url);
+		this.request.addHeader(secretHeaderName, secret + "invalid");
+		assertFalse(this.matcher.matches(new ServletServerHttpRequest(request)));
+	}
+
+
+	@Test
+	public void matchesIgnoresNoSecret() throws Exception {
+		request = new MockHttpServletRequest("GET", url);
+		assertFalse(this.matcher.matches(new ServletServerHttpRequest(request)));
+	}
+}

--- a/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/test/HttpTunnelIntegrationTest.java
+++ b/spring-boot-developer-tools/src/test/java/org/springframework/boot/developertools/tunnel/test/HttpTunnelIntegrationTest.java
@@ -21,12 +21,14 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.developertools.tunnel.client.HeaderClientHttpRequestInterceptor;
 import org.springframework.boot.developertools.tunnel.client.HttpTunnelConnection;
 import org.springframework.boot.developertools.tunnel.client.TunnelClient;
 import org.springframework.boot.developertools.tunnel.client.TunnelConnection;
 import org.springframework.boot.developertools.tunnel.server.HttpTunnelFilter;
 import org.springframework.boot.developertools.tunnel.server.HttpTunnelServer;
 import org.springframework.boot.developertools.tunnel.server.PortProvider;
+import org.springframework.boot.developertools.tunnel.server.SecuredServerHttpRequestMatcher;
 import org.springframework.boot.developertools.tunnel.server.SocketTargetServerConnection;
 import org.springframework.boot.developertools.tunnel.server.StaticPortProvider;
 import org.springframework.boot.developertools.tunnel.server.TargetServerConnection;
@@ -95,13 +97,14 @@ public class HttpTunnelIntegrationTest {
 			PortProvider port = new StaticPortProvider(this.httpServerPort);
 			TargetServerConnection connection = new SocketTargetServerConnection(port);
 			HttpTunnelServer server = new HttpTunnelServer(connection);
-			return new HttpTunnelFilter("/httptunnel", server);
+			SecuredServerHttpRequestMatcher matcher = new SecuredServerHttpRequestMatcher("/httptunnel", "X-AUTH-TOKEN", "secret");
+			return new HttpTunnelFilter(matcher, server);
 		}
 
 		@Bean
 		public TunnelClient tunnelClient() {
 			String url = "http://localhost:" + this.httpServerPort + "/httptunnel";
-			TunnelConnection connection = new HttpTunnelConnection(url);
+			TunnelConnection connection = new HttpTunnelConnection(url, new HeaderClientHttpRequestInterceptor("X-AUTH-TOKEN", "secret"));
 			return new TunnelClient(this.clientPort, connection);
 		}
 

--- a/spring-boot-samples/spring-boot-sample-tunnel/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-tunnel/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 # logging.level.org.springframework.boot.developertools.tunnel.payload.HttpTunnelPayload=TRACE
 
-spring.developertools.remote.enabled=true
+spring.developertools.remote.secret=supersecret


### PR DESCRIPTION
To enable remote Spring Application you specify a secret. For example:

spring.developertools.remote.secret=somethingsupersecret

The RemoteSpringApplication will include the secret in a header
(default X-AUTH-TOKEN). The HttpTunnelFilter will only match on requests
that include the correct secret. The header name can be customized with

spring.developertools.remote.secretHeaderName=customHeaderName

To keep your application and secret secure, you should only specify https
URLs for RemoteSpringApplication's remoteUrl property.