### PR TITLE
Make HttpClientServiceProperties and Group properties public.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/AbstractHttpClientServiceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/AbstractHttpClientServiceProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.http.client.AbstractHttpRequestFac
  * @author Rossen Stoyanchev
  * @author Phillip Webb
  */
-abstract class AbstractHttpClientServiceProperties extends AbstractHttpRequestFactoryProperties {
+public abstract class AbstractHttpClientServiceProperties extends AbstractHttpRequestFactoryProperties {
 
 	/**
 	 * Base url to set in the underlying HTTP client group. By default, set to

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/HttpClientServiceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/HttpClientServiceProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Phillip Webb
  */
 @ConfigurationProperties("spring.http.client.service")
-class HttpClientServiceProperties extends AbstractHttpClientServiceProperties {
+public class HttpClientServiceProperties extends AbstractHttpClientServiceProperties {
 
 	/**
 	 * Group settings.
@@ -44,7 +44,7 @@ class HttpClientServiceProperties extends AbstractHttpClientServiceProperties {
 		this.group = group;
 	}
 
-	static class Group extends AbstractHttpClientServiceProperties {
+	public static class Group extends AbstractHttpClientServiceProperties {
 
 	}
 


### PR DESCRIPTION
Make `HttpClientServiceProperties` and `Group` properties public to allow use in Cloud integrations.