### PR TITLE
Make ReactiveHttpClientServiceProperties and Group properties public

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/reactive/service/AbstractHttpReactiveClientServiceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/reactive/service/AbstractHttpReactiveClientServiceProperties.java
@@ -13,7 +13,7 @@ import org.springframework.boot.autoconfigure.http.client.reactive.AbstractClien
  * @author Rossen Stoyanchev
  * @author Phillip Webb
  */
-abstract class AbstractHttpReactiveClientServiceProperties extends AbstractClientHttpConnectorProperties {
+public abstract class AbstractHttpReactiveClientServiceProperties extends AbstractClientHttpConnectorProperties {
 
 	/**
 	 * Base url to set in the underlying HTTP client group. By default, set to

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/reactive/service/ReactiveHttpClientServiceProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/reactive/service/ReactiveHttpClientServiceProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Phillip Webb
  */
 @ConfigurationProperties("spring.http.reactiveclient.service")
-class ReactiveHttpClientServiceProperties extends AbstractHttpReactiveClientServiceProperties {
+public class ReactiveHttpClientServiceProperties extends AbstractHttpReactiveClientServiceProperties {
 
 	/**
 	 * Group settings.
@@ -44,7 +44,7 @@ class ReactiveHttpClientServiceProperties extends AbstractHttpReactiveClientServ
 		this.group = group;
 	}
 
-	static class Group extends AbstractHttpReactiveClientServiceProperties {
+	public static class Group extends AbstractHttpReactiveClientServiceProperties {
 
 	}
 


### PR DESCRIPTION
Required for Cloud integration.