### PR TITLE
Make HttpServiceClientAutoConfiguration conditional on HttpClientSettingsProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/HttpServiceClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/service/HttpServiceClientAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.web.service.registry.ImportHttpServices;
  */
 @AutoConfiguration(after = { HttpClientAutoConfiguration.class, RestClientAutoConfiguration.class })
 @ConditionalOnClass(RestClientAdapter.class)
-@ConditionalOnBean(HttpServiceProxyRegistry.class)
+@ConditionalOnBean({ HttpServiceProxyRegistry.class, HttpClientSettingsProperties.class })
 @EnableConfigurationProperties(HttpClientServiceProperties.class)
 public class HttpServiceClientAutoConfiguration implements BeanClassLoaderAware {
 


### PR DESCRIPTION
Avoid failing on: 

```
Parameter 1 of method restClientPropertiesHttpServiceGroupConfigurer in org.springframework.boot.autoconfigure.http.client.service.HttpServiceClientAutoConfiguration required a bean of type 'org.springframework.boot.autoconfigure.http.client.HttpClientSettingsProperties' that could not be found.
```
when only `spring-boot-sarter-wbflux` on the classpath. 

Caused by https://github.com/spring-projects/spring-boot/blob/711c53d16c802025343285b90c3dd1f8c60ed1a6/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/HttpClientAutoConfiguration.java#L47.

Alternative solution: make `HttpServiceClientAutoConfiguration` `@Conditional(NotReactiveWebApplicationCondition.class)`